### PR TITLE
Bump Hugo to 0.164.0

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -5,7 +5,7 @@ theme = "hugo-coder"
 defaultcontentlanguage = "en"
 
 [build]
-hugo_version = "0.163.1"
+hugo_version = "0.164.0"
 
 [pagination]
 pagerSize = 20


### PR DESCRIPTION
## Summary
- Bump pinned Hugo version from 0.163.1 to 0.164.0

## Test plan
- [x] Built site with both 0.163.1 and 0.164.0 binaries and diffed full output directory
- [x] Only difference anywhere is the `<meta name=generator>` tag; all asset hashes identical
- [x] Reviewed 0.164.0 release notes for breaking changes: none apply (the one behavior change, `.Render` now erroring on a missing template, is safe since the site's only `.Render` call targets an existing template; the deprecated `resources.PostProcess` isn't used here)
