### PR TITLE
Add Why Sponsor MWTC section and printable prospectus page

### DIFF
--- a/assets/scss/pages.scss
+++ b/assets/scss/pages.scss
@@ -672,3 +672,154 @@ body.colorscheme-dark {
     flex: 1 1 100%;
   }
 }
+
+// ─── Sponsorship prospectus ─────────────────────────────────────────────────────
+// A printable one-pager: same design tokens as the sponsors page, but built to
+// also work as a physical/PDF handout via the @media print block below.
+
+.prospectus-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+.prospectus-back-link {
+  color: var(--teal-on-bg) !important;
+  font-weight: 600;
+  text-decoration: none !important;
+
+  &:hover,
+  &:focus {
+    color: var(--teal-hover) !important;
+  }
+}
+
+.prospectus-print-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--teal-on-bg);
+  background: transparent;
+  color: var(--teal-on-bg);
+  font-size: 1.4rem;
+  font-weight: 700;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+
+  &:hover,
+  &:focus {
+    background: var(--teal);
+    color: var(--navy);
+  }
+}
+
+.prospectus-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.prospectus-eyebrow {
+  margin: 0 0 0.6rem;
+  color: var(--teal-on-bg);
+  font-size: 1.3rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.prospectus-title {
+  margin: 0 0 1.2rem;
+  font-size: 3rem;
+}
+
+.prospectus-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem 2.5rem;
+  font-size: 1.5rem;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  i {
+    color: var(--teal-on-bg);
+  }
+}
+
+.prospectus-tier-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2rem 0 2.5rem;
+  font-size: 1.4rem;
+
+  th,
+  td {
+    text-align: left;
+    vertical-align: top;
+    padding: 1.2rem 1rem;
+    border-bottom: 1px solid var(--teal-15);
+  }
+
+  th {
+    font-size: 1.2rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--teal-on-bg);
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 1.4rem;
+
+    li {
+      margin-bottom: 0.3rem;
+    }
+  }
+}
+
+.prospectus-tier-name {
+  display: block;
+  font-size: 1.7rem;
+  font-weight: 700;
+}
+
+.prospectus-tier-tagline {
+  display: block;
+  opacity: 0.8;
+}
+
+.prospectus-tier-limit {
+  display: block;
+  margin-top: 0.3rem;
+  color: var(--teal-on-bg);
+  font-weight: 700;
+}
+
+.prospectus-tier-price {
+  font-weight: 700;
+  color: var(--teal-on-bg);
+  white-space: nowrap;
+}
+
+.prospectus-contact {
+  font-size: 1.5rem;
+  margin-bottom: 3rem;
+
+  a {
+    color: var(--teal-on-bg) !important;
+
+    &:hover,
+    &:focus {
+      color: var(--teal-hover) !important;
+    }
+  }
+}

--- a/assets/scss/pages.scss
+++ b/assets/scss/pages.scss
@@ -262,6 +262,39 @@ body.colorscheme-dark {
   margin-bottom: 2rem;
 }
 
+// ─── Sponsor value prop ────────────────────────────────────────────────────────
+
+.value-prop-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+  gap: 2rem;
+  margin-bottom: 2.5rem;
+}
+
+.value-prop-card {
+  padding: 2rem;
+  border: 1px solid var(--teal-15);
+  border-radius: 1rem;
+}
+
+.value-prop-icon {
+  font-size: 1.8rem;
+  color: var(--teal-on-bg);
+  margin-bottom: 1rem;
+}
+
+.value-prop-title {
+  margin: 0 0 0.6rem;
+  font-size: 1.7rem;
+}
+
+.value-prop-body {
+  margin: 0;
+  font-size: 1.4rem;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+
 // ─── Sponsors list ────────────────────────────────────────────────────────────
 
 .container.list ul {

--- a/assets/scss/print.scss
+++ b/assets/scss/print.scss
@@ -1,0 +1,54 @@
+// Print-only styles for the sponsorship prospectus (and any other page that
+// wants a clean printed/PDF output). Loaded via a dedicated <link media="print">
+// in layouts/_partials/head/extensions.html, since the theme's own stylesheets
+// are all forced to media="screen" and never apply when printing.
+
+.navigation,
+.footer,
+.float-container,
+.prospectus-actions {
+  display: none !important;
+}
+
+body {
+  background: #fff !important;
+  color: #000 !important;
+}
+
+.container.prospectus {
+  max-width: 100%;
+  padding: 0;
+}
+
+.prospectus-eyebrow,
+.prospectus-meta i,
+.sponsors-section-title,
+.value-prop-icon,
+.prospectus-tier-limit,
+.prospectus-tier-price,
+th {
+  color: #1e6b54 !important;
+}
+
+.value-prop-card,
+.prospectus-tier-table td,
+.prospectus-tier-table th {
+  border-color: #ccc !important;
+}
+
+.value-prop-grid {
+  page-break-inside: avoid;
+}
+
+.prospectus-tier-table tr {
+  page-break-inside: avoid;
+}
+
+a {
+  color: #000 !important;
+  text-decoration: none !important;
+}
+
+@page {
+  margin: 1.5cm;
+}

--- a/content/prospectus/index.md
+++ b/content/prospectus/index.md
@@ -1,0 +1,10 @@
++++
+draft = false
+date = 2026-08-18T00:00:00Z
+title = 'Sponsorship Prospectus'
+disableComments = true
++++
+
+Midwest Tech Conference (MWTC) is a community-run, non-profit IT conference organized by [Mid-MO Technology Group]({{< ref "sponsors/Mid-MO_Tech_Group.md" >}}) to give people in technical industries — and anyone curious about them — a place to network and talk shop. It's built for developers, sysadmins, IT leaders, students, and enthusiasts across mid-Missouri.
+
+MWTC keeps costs low ($10 a ticket, free for students) so the event stays accessible, and that's only possible with sponsor support. As a young, volunteer-run event we don't have historical attendance numbers to share yet, but every sponsorship dollar goes directly toward building something real for the local tech community rather than padding a budget — any surplus after expenses is returned to sponsors or donated.

--- a/layouts/_partials/head/extensions.html
+++ b/layouts/_partials/head/extensions.html
@@ -1,0 +1,13 @@
+{{/*
+  Project override of the theme's (empty) head/extensions.html.
+  The theme forces every stylesheet it links to media="screen", so a
+  print-only stylesheet needs its own <link media="print"> here.
+*/}}
+{{ if hugo.IsServer }}
+  {{ $cssOpts := (dict "enableSourceMap" true ) }}
+  {{ $styles := resources.Get "scss/print.scss" | toCSS $cssOpts }}
+  <link rel="stylesheet" href="{{ $styles.RelPermalink }}" media="print">
+{{ else }}
+  {{ $styles := resources.Get "scss/print.scss" | toCSS | resources.Minify | resources.Fingerprint }}
+  <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}" crossorigin="anonymous" media="print" />
+{{ end }}

--- a/layouts/prospectus/single.html
+++ b/layouts/prospectus/single.html
@@ -1,0 +1,81 @@
+{{ define "title" }} {{ .Title }} · {{ .Site.Title }} {{ end }}
+{{ define "content" }}
+<section class="container prospectus">
+    <div class="prospectus-actions">
+        <a class="prospectus-back-link" href="{{ "sponsors" | relURL }}">&larr; Back to Sponsors</a>
+        <button type="button" class="prospectus-print-btn" onclick="window.print()">
+            <i class="fa-solid fa-print" aria-hidden="true"></i> Print / Save as PDF
+        </button>
+    </div>
+
+    <header class="prospectus-header">
+        <p class="prospectus-eyebrow">Sponsorship Prospectus</p>
+        <h1 class="prospectus-title">{{ .Site.Params.subtitle | default .Site.Title }}</h1>
+        <div class="prospectus-meta">
+            <span><i class="fa-solid fa-calendar-days" aria-hidden="true"></i> {{ .Site.Params.eventDate }}</span>
+            <span><i class="fa-solid fa-clock" aria-hidden="true"></i> {{ .Site.Params.eventTime }}</span>
+            <span><i class="fa-solid fa-location-dot" aria-hidden="true"></i> {{ .Site.Params.eventLocation }}</span>
+        </div>
+    </header>
+
+    {{ .Content }}
+
+    <h2 class="sponsors-section-title">Why Sponsor MWTC?</h2>
+
+    <div class="value-prop-grid">
+        <div class="value-prop-card">
+            <i class="fa-solid fa-users value-prop-icon" aria-hidden="true"></i>
+            <h3 class="value-prop-title">Reach Local Tech Talent</h3>
+            <p class="value-prop-body">Connect with Mid-Missouri developers, sysadmins, IT leaders, and Mizzou students who show up because they want to talk shop &mdash; a warm audience for recruiting.</p>
+        </div>
+        <div class="value-prop-card">
+            <i class="fa-solid fa-bullhorn value-prop-icon" aria-hidden="true"></i>
+            <h3 class="value-prop-title">Build Brand Visibility</h3>
+            <p class="value-prop-body">Your logo on signage, the website, and social media puts your organization in front of the region's tech community as it grows.</p>
+        </div>
+        <div class="value-prop-card">
+            <i class="fa-solid fa-hand-holding-heart value-prop-icon" aria-hidden="true"></i>
+            <h3 class="value-prop-title">Support the Community</h3>
+            <p class="value-prop-body">MWTC is volunteer-run and non-profit. Sponsorships keep tickets affordable, students free, and any surplus is returned to sponsors or donated.</p>
+        </div>
+    </div>
+
+    <h2 class="sponsors-section-title">Sponsorship Packages</h2>
+
+    <table class="prospectus-tier-table">
+        <thead>
+            <tr>
+                <th>Tier</th>
+                <th>Price</th>
+                <th>Benefits</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{ range site.Data.sponsor_tiers }}
+            <tr>
+                <td>
+                    <span class="prospectus-tier-name">{{ .name }}</span>
+                    <span class="prospectus-tier-tagline">{{ .tagline }}</span>
+                    {{ with .limit }}<span class="prospectus-tier-limit">{{ . }} spots</span>{{ end }}
+                </td>
+                <td class="prospectus-tier-price">{{ .price }}</td>
+                <td>
+                    <ul>
+                        {{ range .benefits }}<li>{{ . }}</li>{{ end }}
+                    </ul>
+                </td>
+            </tr>
+            {{ end }}
+        </tbody>
+    </table>
+
+    <h2 class="sponsors-section-title">Get in Touch</h2>
+
+    <p class="prospectus-contact">
+        Ready to sponsor, or want to put together something custom or in-kind? Email
+        <a href="mailto:sponsor@mwtc.io?subject=Sponsor%20Opportunity&body=Hello!%20%0A%0AI%20would%20like%20to%20discuss%20becoming%20a%20sponsor%20for%20the%20Mid-West%20Tech%20Conference.%20I%20am%20interested%20in%20the%20%5BPlatinum%2FGold%2FSilver%2FBronze%5D%20tier.%20%0A%0AI%20can%20be%20reached%20at%20%5Bphone%20or%20email%5D">sponsor@mwtc.io</a>
+        &mdash; or find full sponsor details at
+        <a href="{{ absURL "sponsors" }}">{{ absURL "sponsors" }}</a>.
+    </p>
+</section>
+{{ end }}

--- a/layouts/sponsors/list.html
+++ b/layouts/sponsors/list.html
@@ -62,6 +62,11 @@
 
     <h2 class="sponsors-section-title">Sponsorship Packages</h2>
 
+    <p class="tier-payment-note">
+        Sharing this with someone else at your company?
+        <a href="{{ "prospectus" | relURL }}">View the printable sponsorship prospectus</a>.
+    </p>
+
     <div class="tier-grid">
         {{ range site.Data.sponsor_tiers }}
         {{ $tier := . }}

--- a/layouts/sponsors/list.html
+++ b/layouts/sponsors/list.html
@@ -10,6 +10,26 @@
     </header>
     {{ .Content }}
 
+    <h2 class="sponsors-section-title">Why Sponsor MWTC?</h2>
+
+    <div class="value-prop-grid">
+        <div class="value-prop-card">
+            <i class="fa-solid fa-users value-prop-icon" aria-hidden="true"></i>
+            <h3 class="value-prop-title">Reach Local Tech Talent</h3>
+            <p class="value-prop-body">Connect with Mid-Missouri developers, sysadmins, IT leaders, and Mizzou students who show up because they want to talk shop &mdash; a warm audience for recruiting.</p>
+        </div>
+        <div class="value-prop-card">
+            <i class="fa-solid fa-bullhorn value-prop-icon" aria-hidden="true"></i>
+            <h3 class="value-prop-title">Build Brand Visibility</h3>
+            <p class="value-prop-body">Your logo on signage, the website, and social media puts your organization in front of the region's tech community as it grows.</p>
+        </div>
+        <div class="value-prop-card">
+            <i class="fa-solid fa-hand-holding-heart value-prop-icon" aria-hidden="true"></i>
+            <h3 class="value-prop-title">Support the Community</h3>
+            <p class="value-prop-body">MWTC is volunteer-run and non-profit. Sponsorships keep tickets affordable, students free, and any surplus is returned to sponsors or donated.</p>
+        </div>
+    </div>
+
     <h2 class="sponsors-section-title">Our Sponsors</h2>
 
     {{ $tierOrder := slice "Platinum" "Gold" "Silver" "Bronze" "Friend" }}

--- a/layouts/sponsors/list.html
+++ b/layouts/sponsors/list.html
@@ -10,26 +10,6 @@
     </header>
     {{ .Content }}
 
-    <h2 class="sponsors-section-title">Why Sponsor MWTC?</h2>
-
-    <div class="value-prop-grid">
-        <div class="value-prop-card">
-            <i class="fa-solid fa-users value-prop-icon" aria-hidden="true"></i>
-            <h3 class="value-prop-title">Reach Local Tech Talent</h3>
-            <p class="value-prop-body">Connect with Mid-Missouri developers, sysadmins, IT leaders, and Mizzou students who show up because they want to talk shop &mdash; a warm audience for recruiting.</p>
-        </div>
-        <div class="value-prop-card">
-            <i class="fa-solid fa-bullhorn value-prop-icon" aria-hidden="true"></i>
-            <h3 class="value-prop-title">Build Brand Visibility</h3>
-            <p class="value-prop-body">Your logo on signage, the website, and social media puts your organization in front of the region's tech community as it grows.</p>
-        </div>
-        <div class="value-prop-card">
-            <i class="fa-solid fa-hand-holding-heart value-prop-icon" aria-hidden="true"></i>
-            <h3 class="value-prop-title">Support the Community</h3>
-            <p class="value-prop-body">MWTC is volunteer-run and non-profit. Sponsorships keep tickets affordable, students free, and any surplus is returned to sponsors or donated.</p>
-        </div>
-    </div>
-
     <h2 class="sponsors-section-title">Our Sponsors</h2>
 
     {{ $tierOrder := slice "Platinum" "Gold" "Silver" "Bronze" "Friend" }}
@@ -59,6 +39,26 @@
           </a>
         </li>
     </ul>
+
+    <h2 class="sponsors-section-title">Why Sponsor MWTC?</h2>
+
+    <div class="value-prop-grid">
+        <div class="value-prop-card">
+            <i class="fa-solid fa-users value-prop-icon" aria-hidden="true"></i>
+            <h3 class="value-prop-title">Reach Local Tech Talent</h3>
+            <p class="value-prop-body">Connect with Mid-Missouri developers, sysadmins, IT leaders, and Mizzou students who show up because they want to talk shop &mdash; a warm audience for recruiting.</p>
+        </div>
+        <div class="value-prop-card">
+            <i class="fa-solid fa-bullhorn value-prop-icon" aria-hidden="true"></i>
+            <h3 class="value-prop-title">Build Brand Visibility</h3>
+            <p class="value-prop-body">Your logo on signage, the website, and social media puts your organization in front of the region's tech community as it grows.</p>
+        </div>
+        <div class="value-prop-card">
+            <i class="fa-solid fa-hand-holding-heart value-prop-icon" aria-hidden="true"></i>
+            <h3 class="value-prop-title">Support the Community</h3>
+            <p class="value-prop-body">MWTC is volunteer-run and non-profit. Sponsorships keep tickets affordable, students free, and any surplus is returned to sponsors or donated.</p>
+        </div>
+    </div>
 
     <h2 class="sponsors-section-title">Sponsorship Packages</h2>
 


### PR DESCRIPTION
## Summary
- Add a "Why Sponsor MWTC?" value-prop section to the sponsors page, positioned below the current sponsors list
- Add a printable sponsorship prospectus page (with dedicated print stylesheet)

## Test plan
- [ ] Verify sponsors page renders the new section correctly in light/dark mode
- [ ] Verify prospectus page prints cleanly (check print preview)