### PR TITLE
Add Integrated Cyber Defense Solutions as a Platinum sponsor

### DIFF
--- a/content/sponsors/Integrated_Cyber_Defense_Solutions.md
+++ b/content/sponsors/Integrated_Cyber_Defense_Solutions.md
@@ -1,0 +1,16 @@
++++
+draft = false
+date = 2026-09-02T00:00:00Z
+title = 'Integrated Cyber Defense Solutions'
+logo = "/images/icds.png"
+logo_alt = "Integrated Cyber Defense Solutions Logo"
+level = 'Platinum'
++++
+
+{{< logo >}}
+
+Integrated Cyber Defense Solutions (ICDS) is a Missouri-based cybersecurity company helping organizations strengthen their security, understand their risk, and prepare for the threats they face every day.
+
+ICDS specializes in penetration testing, purple teaming, cybersecurity assessments, cyber defense, vulnerability management, and compliance services, including CMMC and NIST 800-171. Our approach combines hands-on technical experience with practical guidance designed to help organizations improve security without adding unnecessary complexity.
+
+We’re proud to support the Mid-MO Technology Group and its mission to bring technology professionals together, share ideas, and continue building a stronger technology community here in Mid-Missouri.

--- a/content/sponsors/Integrated_Cyber_Defense_Solutions.md
+++ b/content/sponsors/Integrated_Cyber_Defense_Solutions.md
@@ -5,6 +5,7 @@ title = 'Integrated Cyber Defense Solutions'
 logo = "/images/icds.png"
 logo_alt = "Integrated Cyber Defense Solutions Logo"
 level = 'Platinum'
+externalLink = "https://icds.us"
 +++
 
 {{< logo >}}

--- a/layouts/sponsors/single.html
+++ b/layouts/sponsors/single.html
@@ -19,6 +19,9 @@
           <img src="{{ .Params.featuredImage | relURL }}" alt="Featured image"/>
         {{ end }}
         {{ .Content }}
+        {{ with .Params.externalLink }}
+          <p class="sponsor-website-link"><a href="{{ . }}">Visit website &rarr;</a></p>
+        {{ end }}
       </div>
 
 


### PR DESCRIPTION
## Summary
- Adds Integrated Cyber Defense Solutions (ICDS) as a Platinum sponsor, using their uploaded logo (`static/images/icds.png`)
- Links to their website (icds.us) from both the sponsor card on the main sponsors list and their individual sponsor page

## Test plan
- [x] Verified locally: ICDS appears first under Platinum tier, Platinum spot counter correctly reads "2 of 3 spots available," logo and blurb render correctly on the detail page, and both the card and "Visit website" link point to https://icds.us