### PR TITLE
Fix sponsor logo visibility in dark mode

### DIFF
--- a/assets/scss/pages.scss
+++ b/assets/scss/pages.scss
@@ -377,6 +377,39 @@ body.colorscheme-dark {
   text-align: center;
 }
 
+// ─── Sponsor Page Logo ───────────────────────────────────────────────────────
+
+.sponsor-page-logo {
+  display: inline-block;
+  max-width: 100%;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  border-radius: 0.6rem;
+  background: #fff;
+
+  img {
+    // A percentage width/max-width here would need to resolve against this
+    // element's own shrink-to-fit size, which some browsers can't do for an
+    // SVG that has no explicit width/height (only a viewBox) — it collapses
+    // to 0 instead of falling back to the image's default intrinsic size.
+    // An absolute width sidesteps that ambiguity.
+    width: 20rem;
+    max-width: 100%;
+    height: auto;
+    display: block;
+  }
+}
+
+.colorscheme-dark .sponsor-page-logo {
+  background: rgba(255, 255, 255, 0.85);
+}
+
+@media (prefers-color-scheme: dark) {
+  .colorscheme-auto .sponsor-page-logo {
+    background: rgba(255, 255, 255, 0.85);
+  }
+}
+
 .sponsor-card-tier {
   display: block;
   text-align: center;

--- a/layouts/shortcodes/logo.html
+++ b/layouts/shortcodes/logo.html
@@ -1,1 +1,7 @@
-{{ partial "logo.html" (dict "Page" .Page "Params" (dict "name" (.Get "name") "width" (.Get "width"))) }}
+{{/* Wrapped in a light box so logos with dark or transparent artwork (like
+     Veterans United's SVG) stay visible against the sponsor page's dark-mode
+     background, matching the treatment sponsor-card-logo already gives
+     logos on the sponsors list. */}}
+<div class="sponsor-page-logo">
+  {{ partial "logo.html" (dict "Page" .Page "Params" (dict "name" (.Get "name") "width" (.Get "width"))) }}
+</div>


### PR DESCRIPTION
## Summary
- Wraps sponsor detail page logos in a light box (matching the treatment already used on the sponsors list cards) so dark or transparent-background logos stay visible against the dark-mode background — Veterans United's SVG logo was nearly invisible in dark mode before this.
- Along the way, found and fixed a real (worse) bug: that same SVG has no explicit width/height (only a viewBox), and was actually rendering unbounded at ~860px wide with no cap. Wrapping it in a percentage-sized container would have collapsed it to 0×0 instead — switched to an absolute width so it sizes correctly either way.

## Test plan
- [x] Verified locally in a real browser: Veterans United's logo is now clearly visible in both light and dark mode at a sane size, and Mid-MO Technology Group's and Integrated Cyber Defense Solutions' logos (PNG) still render correctly with no regression.