### PR TITLE
Sponsor cards should link to their own page, not their website

### DIFF
--- a/layouts/sponsors/li.html
+++ b/layouts/sponsors/li.html
@@ -1,5 +1,5 @@
 <li class="sponsor-card">
-  <a class="sponsor-card-link" href="{{ .Params.externalLink | default .RelPermalink }}">
+  <a class="sponsor-card-link" href="{{ .RelPermalink }}">
     <div class="sponsor-card-logo">
       {{ with .Params.logo }}
         <img src="{{ . | relURL }}" alt="{{ $.Params.logo_alt | default $.Title }}" loading="lazy">


### PR DESCRIPTION
## Summary
- The sponsors list card linked straight to a sponsor's external website when `externalLink` was set (ICDS is currently the only sponsor using it), instead of their own mwtc.io sponsor page like every other sponsor.
- Cards now always link to the sponsor's own page for consistency; the "Visit website" link added on the sponsor's detail page (PR #16) is the intended place to reach their external site.

## Test plan
- [x] Verified locally: hovering/clicking the ICDS card on `/sponsors/` now goes to `/sponsors/integrated_cyber_defense_solutions/` instead of `https://icds.us`.