### PR TITLE
Fix homepage Platinum sponsor logo visibility

### DIFF
--- a/assets/scss/hero.scss
+++ b/assets/scss/hero.scss
@@ -276,7 +276,7 @@
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  gap: 3rem;
+  gap: 1.5rem;
 
   a {
     display: inline-flex;
@@ -293,4 +293,16 @@
       opacity: 1;
     }
   }
+}
+
+// The bar's background is always dark navy regardless of color scheme, so
+// sponsor logos with dark or transparent artwork (like ICDS's) need a fixed
+// light backing to stay visible — no colorscheme-dark variant needed here.
+.sponsor-bar-logo-box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem 1.5rem;
+  border-radius: 0.6rem;
+  background: #fff;
 }

--- a/layouts/partials/home/sponsor-bar.html
+++ b/layouts/partials/home/sponsor-bar.html
@@ -5,7 +5,9 @@
     <p class="sponsor-bar-label">Platinum Sponsors</p>
     <div class="sponsor-bar-logos">
       {{ range $platinumSponsors }}
-        {{ partial "logo.html" (dict "Page" . "Params" (dict "width" "180")) }}
+        <div class="sponsor-bar-logo-box">
+          {{ partial "logo.html" (dict "Page" . "Params" (dict "width" "180")) }}
+        </div>
       {{ end }}
     </div>
   </div>


### PR DESCRIPTION
## Summary
Found while checking the live site on mobile: the homepage's "Platinum Sponsors" bar has an always-dark navy background, and ICDS's dark-blue logo was rendering directly against it with no backing — nearly invisible. Same root cause as the Veterans United fix from earlier, just in a spot (the homepage sponsor bar, which calls the logo partial directly) that fix didn't cover.

Wraps each logo in a white box, matching the treatment already used on the sponsors list and detail pages.

## Test plan
- [x] Verified on both mobile (iPhone 13 viewport) and desktop: ICDS logo now clearly visible against a white box in the Platinum Sponsors bar, no console errors, no layout regressions.